### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/privanetix-node/spheron.yaml
+++ b/privanetix-node/spheron.yaml
@@ -12,7 +12,7 @@ services:
     env:
       - KEYSTORE_PASSWORD=<KEYSTORE_PASSWORD>
 profiles:
-  name: privasea-accelaration-node
+  name: privasea-acceleration-node
   duration: 8h
   mode: provider
   tier:


### PR DESCRIPTION
Fix typo `accelaration` -> `acceleration`